### PR TITLE
res => null prevents responseText from being surface for custom error…

### DIFF
--- a/src/js/app/utils/createFetchFunction.js
+++ b/src/js/app/utils/createFetchFunction.js
@@ -20,7 +20,7 @@ export const createFetchFunction = (apiUrl = '', action) => {
 
     // set onload hanlder
     const onload = action.onload || (res => res);
-    const onerror = action.onerror || (res => null);
+    const onerror = action.onerror || (res => res);
 
     // internal handler
     return (url, load, error, progress, abort, headers) => {


### PR DESCRIPTION
This should allow for surfacing a custom error message in the response or responseText fields of the xhr response.